### PR TITLE
Added skipping of PASSED in console / added more help on mutiple Excludes/Includes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/clamav/ClamAvRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/clamav/ClamAvRecorder.java
@@ -90,6 +90,8 @@ public class ClamAvRecorder extends Recorder {
 
         PrintStream logger = listener.getLogger();
 
+        logger.println("[ClamAV] started scanning.");
+
         FilePath ws = build.getWorkspace();
         if (ws == null) {
             return false;
@@ -132,7 +134,7 @@ public class ClamAvRecorder extends Recorder {
             	}
             }
         }
-        logger.println("[ClamAV] " + (System.currentTimeMillis() - start) + "ms took.");
+        logger.println("[ClamAV] took " + (System.currentTimeMillis() - start) + "ms.");
 
         build.getActions().add(new ClamAvBuildAction(build, results));
 

--- a/src/main/resources/org/jenkinsci/plugins/clamav/ClamAvRecorder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/clamav/ClamAvRecorder/global.jelly
@@ -10,6 +10,9 @@
         <f:entry title="${%Scan archived artifacts}" field="scanArchivedArtifacts">
             <f:checkbox /> 
         </f:entry>    
+        <f:entry title="${%Console trace only warnings or errors}" field="consoleTraceOnlyWarningsOrErrors">
+            <f:checkbox /> 
+        </f:entry>    
         <f:advanced>
             <f:entry title="${%Timeout}" field="timeout">
                 <f:textbox name="timeout" />

--- a/src/main/resources/org/jenkinsci/plugins/clamav/ClamAvRecorder/help-excludes.html
+++ b/src/main/resources/org/jenkinsci/plugins/clamav/ClamAvRecorder/help-excludes.html
@@ -2,4 +2,5 @@
   Optionally specify <a href='http://ant.apache.org/manual/Types/fileset.html'>the 'excludes' pattern</a>,
   such as "foo/bar/**/*". A file that matches this mask will not be checked even if it matches the
   mask specified in 'files to archive' section.
+  If you need to exclude multiple folders, paths or files use the path delimiter "," e.g. **/.svn/**,**/target/**
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/clamav/ClamAvRecorder/help-includes.html
+++ b/src/main/resources/org/jenkinsci/plugins/clamav/ClamAvRecorder/help-includes.html
@@ -3,4 +3,5 @@
    See <a href='http://ant.apache.org/manual/Types/fileset.html'>
    the @includes of Ant fileset</a> for the exact format.
    The base directory is <a href='ws/'>the workspace</a>.
+   If you need to include multiple folders, paths or files use the path delimiter "," e.g. **/src/**,**/images/**
 </div>


### PR DESCRIPTION
The clamav plugin is great!
The thing is, that it is very noisy in the console, since every file is displayed in the console. I've added a switch consoleTraceOnlyWarningsOrErrors which gives the jenkins admin the possibility to disable the expected default "PASSED" and only displays INFECTED or SKIPPED.

Additionally I've more help for multiple excludes and includes for the user. The doc of ANT isn't very helpful to see how multiple excludes/includes should work.

And it would be nice if you could mention my name for the addition ;-)
